### PR TITLE
Added basic istanbul report generation

### DIFF
--- a/setup/default/.gitignore
+++ b/setup/default/.gitignore
@@ -10,6 +10,10 @@ node_modules/
 npm-debug.log
 debug.log
 
+# Code coverage
+coverage.json
+coverage/
+
 # Added by shenanigans-manager for maps testing
 Maps.test.ts
 

--- a/setup/package.json
+++ b/setup/package.json
@@ -9,6 +9,7 @@
     "chai": "^4.1.2",
     "concurrently": "^3.5.1",
     "glob": "^7.1.2",
+    "istanbul": "^0.4.5",
     "lolex": "^2.3.2",
     "mkdirp": "^0.5.1",
     "mocha": "^5.0.5",
@@ -41,6 +42,11 @@
     "src:tsc": "tsc -p .",
     "src:tslint": "tslint -c tslint.json -p tsconfig.json -t stylish",
     "test": "npm run test:setup && npm run test:run",
+    "test:coverage": "npm run test:coverage:generate-html && npm run test:coverage:instrument && npm run test:coverage:run && npm run test:coverage:report",
+    "test:coverage:generate-html": "shenanigans-manager generate-test-html --source instrumented",
+    "test:coverage:instrument": "istanbul instrument src -o instrumented",
+    "test:coverage:report": "istanbul report html",
+    "test:coverage:run": "mocha-headless-chrome --coverage coverage.json --file test/index.instrumented.html",
     "test:run": "mocha-headless-chrome --file test/index.html",
     "test:setup": "npm run test:setup:dir && npm run test:setup:copy && npm run test:setup:html && npm run test:setup:tsc",
     "test:setup:copy": "npm run test:setup:copy:default",
@@ -49,6 +55,7 @@
     "test:setup:html": "shenanigans-manager generate-test-html",
     "test:setup:tsc": "tsc -p test",
     "verify": "npm run src && npm run test && npm run dist && npm run docs",
+    "verify:coverage": "npm run src && npm run test:coverage && npm run dist && npm run docs",
     "watch": "concurrently \"tsc -p . -w\" --raw \"chokidar src/**/*.test.t* --command \"\"npm run test:setup:html\"\" --silent\" --raw"
   },
   "types": "./src/index.d.ts"

--- a/src/commands/generateTestHtml.ts
+++ b/src/commands/generateTestHtml.ts
@@ -8,9 +8,19 @@ import { getDependencyNamesAndExternalsOfPackage, globAsync, parseFileJson } fro
 import { EnsureRepositoryExists } from "./ensureRepositoryExists";
 
 /**
+ * Arguments for a GenerateTestHtml command.
+ */
+export interface IGenerateTestHtmlArgs extends IRepositoryCommandArgs {
+    /**
+     * Directory to load source files from, if not src.
+     */
+    source?: string;
+}
+
+/**
  * Generates the HTML page for a repository's tests.
  */
-export const GenerateTestHtml = async (runtime: IRuntime, args: IRepositoryCommandArgs) => {
+export const GenerateTestHtml = async (runtime: IRuntime, args: IGenerateTestHtmlArgs) => {
     defaultPathArgs(args, "directory", "repository");
 
     await EnsureRepositoryExists(runtime, args);
@@ -19,10 +29,14 @@ export const GenerateTestHtml = async (runtime: IRuntime, args: IRepositoryComma
     const basePackageContents = await parseFileJson<IShenanigansPackage>(basePackageLocation);
 
     const testTemplate = (await fs.readFile(path.resolve(__dirname, "../../setup/test.html"))).toString();
-    const testPaths = (await globAsync(path.resolve(args.directory, args.repository, "src/**/*.test.ts*")))
+    let testPaths = (await globAsync(path.resolve(args.directory, args.repository, "src/**/*.test.ts*")))
         .map((testPath) => testPath.replace(/\.test\.(tsx|ts)/gi, ".test.js"))
         .map((testPath) => path.join("..", path.relative(path.join(args.directory, args.repository), testPath))
             .replace(/\\/g, "/"));
+
+    if (args.source !== undefined) {
+        testPaths = testPaths.map((testPath: string): string => testPath.replace("/src/", `/${args.source}/`));
+    }
 
     const { dependencyNames, externals } = await getDependencyNamesAndExternalsOfPackage(basePackageLocation);
 
@@ -35,7 +49,11 @@ export const GenerateTestHtml = async (runtime: IRuntime, args: IRepositoryComma
             testPaths,
         });
 
+    const testFileName = args.source === undefined
+        ? "test/index.html"
+        : `test/index.${args.source}.html`;
+
     await fs.writeFile(
-        path.join(args.directory, args.repository, "test/index.html"),
+        path.join(args.directory, args.repository, testFileName),
         newTestContents);
 };


### PR DESCRIPTION
Generates a coverage.json and coverage/ directory with HTML coverage files. Doesn't get run as part of the normal build yet.

Fixes #49.